### PR TITLE
Improve precision

### DIFF
--- a/main.py
+++ b/main.py
@@ -257,7 +257,7 @@ def fetch_yelp_data(lat, lng):
     categories = ['grocery', 'trainstations', 'transport', 'bars', 'climbing', 'cafeteria', 'libraries',
                   'religiousorgs', 'sports_clubs', 'fitness']
     location_categories = YELP_API.fetch_all_locations(lat, lng, ','.join(categories),
-                                                       distance_threshold=60, radius=50)
+                                                       distance_threshold=60, radius=17)
 
     #  if request returns None, return empty list
     if location_categories is None:

--- a/yelp.py
+++ b/yelp.py
@@ -48,7 +48,7 @@ class Yelp(object):
         }
 
     @staticmethod
-    def yelp_search(headers, lat, lng, radius=50, limit=50, term='', categories=''):
+    def yelp_search(headers, lat, lng, radius=17, limit=50, term='', categories=''):
         """
         Queries Yelp with the given parameters.
 
@@ -118,7 +118,7 @@ class Yelp(object):
 
         return nearby_hardcoded_cats
 
-    def fetch_all_locations(self, lat, lng, categories, distance_threshold=60, radius=50):
+    def fetch_all_locations(self, lat, lng, categories, distance_threshold=60, radius=17):
         """
         Fetch all categories and locations, including hardcoded, given a lat and lng location.
 


### PR DESCRIPTION
Summary: Diff looks larger than it should!  I switched up the ordering of how to parse the weather response, depending on whether the response came back empty or not.  Then, the Yelp Business query radius was reduced to 17m, instead of 50m.  Based on data from several test cases, this has higher precision (and thus less categories recalled that are not relevant)

Tests: 
Locally...When the weather API was broken for a little bit, calls to the server would not throw errors in each request.  

In production... No errors thrown so far