### PR TITLE
Return distance information in place metadata dictionaries

### DIFF
--- a/.idea/affordance-aware.iml
+++ b/.idea/affordance-aware.iml
@@ -5,7 +5,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/env" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.7 (affordance-aware-2jrGZpwF)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (affordanceaware-tf1zQI5Q)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="R Skeletons" level="application" />
     <orderEntry type="library" name="R User Library" level="project" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7 (affordance-aware-2jrGZpwF)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7 (affordanceaware-tf1zQI5Q)" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="3" />
   </component>

--- a/main.py
+++ b/main.py
@@ -69,22 +69,22 @@ HARDCODED_LOCATION = [
         # ("parks", (42.057300, -87.679615))               # haven and orrington
 ]
 # get configuration variables for hardcoded location threshold and yelp query radius
-HARDCODED_LOCATION_DISTANCE_THRESHOLD = json.loads(environ.get("HARDCODED_LOCATION_DISTANCE_THRESHOLD"))
+HARDCODED_LOCATION_DISTANCE_THRESHOLD = environ.get("HARDCODED_LOCATION_DISTANCE_THRESHOLD")
 if HARDCODED_LOCATION_DISTANCE_THRESHOLD is None:
     # default to 60 meters
     HARDCODED_LOCATION_DISTANCE_THRESHOLD = 60
     print("HARDCODED_LOCATION_DISTANCE_THRESHOLD not specified. Default to {} minutes.".format(HARDCODED_LOCATION_DISTANCE_THRESHOLD))
 else:
-    HARDCODED_LOCATION_DISTANCE_THRESHOLD = int(HARDCODED_LOCATION_DISTANCE_THRESHOLD)
+    HARDCODED_LOCATION_DISTANCE_THRESHOLD = int(json.loads(HARDCODED_LOCATION_DISTANCE_THRESHOLD))
 
 
-YELP_QUERY_RADIUS = json.loads(environ.get("YELP_QUERY_RADIUS"))
+YELP_QUERY_RADIUS = environ.get("YELP_QUERY_RADIUS")
 if YELP_QUERY_RADIUS is None:
     # default to 30 meters
     YELP_QUERY_RADIUS = 30
     print("YELP_QUERY_RADIUS not specified. Default to {} minutes.".format(YELP_QUERY_RADIUS))
 else:
-    YELP_QUERY_RADIUS = int(YELP_QUERY_RADIUS)
+    YELP_QUERY_RADIUS = int(json.loads(YELP_QUERY_RADIUS))
 
 # setup Yelp API with configuration variables
 YELP_API = Yelp(environ.get("YELP_API_KEY"), hardcoded_locations=HARDCODED_LOCATION)
@@ -255,21 +255,24 @@ def get_weather_time_conditions_as_keyvalues(lat, lng):
 
 def place_categories_dict_as_keyvalues(place_categories_dict):
     """
-    :param place_categories_dict: [dict] {'bat_17_evanston': ['sandwiches', 'sportsbars'],
-                                          'le_peep_evanston': ['breakfast']}
+    :param place_categories_dict: [dict] {'bat_17_evanston': {'distance': 17.0, 'categories': ['sandwiches', 'sportsbars']},
+                                          'le_peep_evanston': {'distance': 25.0, 'categories': ['breakfast']} }
     :return res: [dict] {
                             'bat_17_evanston': {
                                 'sandwiches': True,
-                                'sportsbars': True
+                                'sportsbars': True,
+                                'distance': 17.0
                              },
                              'le_peep_evanston': {
-                                'breakfast': True
+                                'breakfast': True,
+                                'distance': 25.0
                              }
                         }
     """
     res = {}
-    for place, category_list in place_categories_dict.items():
-        nested_category_dict = {category: True for category in category_list}
+    for place, nested_place_metadata in place_categories_dict.items():
+        nested_category_dict = {category: True for category in nested_place_metadata['categories']}
+        nested_category_dict['distance'] = nested_place_metadata['distance']
         res[place] = nested_category_dict
     return res
 

--- a/test_main.py
+++ b/test_main.py
@@ -1,12 +1,14 @@
 """From root of project, call
 python -m unittest test_main
 
-
+Must run local mongod instance, i.e.
+mongod --config /usr/local/etc/mongod.conf
 """
 import unittest
 from main import (
     get_weather_time_conditions_as_keyvalues,
-    get_current_conditions_as_keyvalues
+    get_current_conditions_as_keyvalues,
+    place_categories_dict_as_keyvalues
 )
 
 BAT17 = {'lat': 42.048735, 'lng': -87.683187}
@@ -28,4 +30,23 @@ class TestEndPointHelpers(unittest.TestCase):
         current_conditions = get_current_conditions_as_keyvalues(BAT17['lat'], BAT17['lng'])
         print("location_keyvalues:\n {}".format(current_conditions))
         self.assertIn('bat_17_evanston', current_conditions)
+        nested_place_metadata = current_conditions['bat_17_evanston']
+        self.assertIn('categories', nested_place_metadata)
+        self.assertIn('distance', nested_place_metadata)
+
+    def test_place_categories_dict_as_keyvalues(self):
+        place_categories_dict = {'bat_17_evanston': {'distance': 17.0, 'categories': ['sandwiches', 'sportsbars']},
+                                 'le_peep_evanston': {'distance': 25.0, 'categories': ['breakfast']}}
+        as_keyvals = {
+            'bat_17_evanston': {
+                'sandwiches': True,
+                'sportsbars': True,
+                'distance': 17.0
+             },
+            'le_peep_evanston': {
+                'breakfast': True,
+                'distance': 25.0
+            }
+        }
+        self.assertEqual(place_categories_dict_as_keyvalues(place_categories_dict), as_keyvals)
 

--- a/test_yelp.py
+++ b/test_yelp.py
@@ -1,5 +1,7 @@
 """From root of project, call
 python -m unittest test_yelp
+
+Run this in python 3.7, there's wonky things between how str vs unicode is handled in py2 vs py3
 """
 import unittest
 from os import environ
@@ -17,29 +19,39 @@ class TestYelpMethods(unittest.TestCase):
 
     def test_fetch_hardcoded_locations_one_retrieved(self):
         """return looks like
-        {'sargent_hall_evanston': ['cafeteria']}
+        {'sargent_hall_evanston': {'categories': ['cafeteria'], 'distance': 30.0} }
         """
-        place_category_dict = YELP_API.fetch_hardcoded_locations(42.058813, -87.675602)
+        place_category_dict = YELP_API.fetch_hardcoded_locations(42.058813, -87.675602, 60.0)
         self.assertEqual(type(place_category_dict), dict)
 
         text_type = str # starts as string in hardcoded
-        place, category_list = place_category_dict.items()[0]
-        self.assertEqual(type(place), text_type)
-        self.assertEqual(type(category_list), list)
-        category = category_list[0]
-        self.assertEqual(type(category), text_type)
-        print(place_category_dict)
+        self.assertEqual(len(place_category_dict), 1)
+        for place, nested_place_metadata in place_category_dict.items():
+            self.assertEqual(type(place), text_type)
+            self.assertEqual(type(nested_place_metadata), dict)
+            self.assertIn('categories', nested_place_metadata)
+            self.assertIn('distance', nested_place_metadata)
+            category_list = nested_place_metadata['categories']
+            self.assertEqual(type(category_list), list)
+            category = category_list[0]
+            self.assertEqual(type(category), text_type)
+            print(place_category_dict)
 
     def test_fetch_hardcoded_locations_many_retrieved(self):
         """return looks like
-        {'lakefill_southtip_evanston': ['parks', 'lakes'], 'sargent_hall_evanston': ['cafeteria']}
+        {'lakefill_southtip_evanston': {'categories': ['parks', 'lakes'], 'distance': 56.0},
+         'sargent_hall_evanston': {'categories': ['cafeteria'], 'distance': 100.0}
         """
         place_category_dict = YELP_API.fetch_hardcoded_locations(42.058813, -87.675602, 10000)
         self.assertEqual(type(place_category_dict), dict)
 
         text_type = str # starts as string in hardcoded
-        for place, category_list in place_category_dict.items():
+        for place, nested_place_metadata in place_category_dict.items():
             self.assertEqual(type(place), text_type)
+            self.assertEqual(type(nested_place_metadata), dict)
+            self.assertIn('categories', nested_place_metadata)
+            self.assertIn('distance', nested_place_metadata)
+            category_list = nested_place_metadata['categories']
             self.assertEqual(type(category_list), list)
             category = category_list[0]
             self.assertEqual(type(category), text_type)
@@ -47,15 +59,21 @@ class TestYelpMethods(unittest.TestCase):
 
     def test_fetch_yelp_locations(self):
         """return looks like
-        {'bat_17_evanston': ['sandwiches', 'sportsbars'], 'le_peep_evanston': ['breakfast']}
+        {'bat_17_evanston': {'categories': ['sandwiches', 'sportsbars'], 'distance': 17.0},
+         'le_peep_evanston': {'categories': ['breakfast'], 'distance': 30.0}}
         """
         categories = ['grocery', 'trainstations', 'transport', 'bars', 'climbing', 'cafeteria', 'libraries',
                       'religiousorgs', 'sports_clubs', 'fitness']
         place_category_dict = YELP_API.fetch_yelp_locations(
             lat=42.048735, lng=-87.683187, categories=categories, radius=30)
         print(place_category_dict)
-        for place, category_list in place_category_dict.items():
+        for place, nested_place_metadata in place_category_dict.items():
             self.assertTrue(isinstance(place, str) or isinstance(place, unicode))
+            self.assertEqual(type(nested_place_metadata), dict)
+            self.assertIn('categories', nested_place_metadata)
+            self.assertIn('distance', nested_place_metadata)
+            category_list = nested_place_metadata['categories']
+
             self.assertEqual(type(category_list), list)
             category = category_list[0]
             self.assertTrue(isinstance(category, str) or isinstance(category, unicode))
@@ -67,9 +85,12 @@ class TestYelpMethods(unittest.TestCase):
         place_category_dict = YELP_API.fetch_all_locations(
             lat=42.048735, lng=-87.683187, categories=categories, distance_threshold=10000, radius=30)
         print(place_category_dict)
-        text_type = unicode # starts as string in hardcoded
-        for place, category_list in place_category_dict.items():
+        for place, nested_place_metadata in place_category_dict.items():
             self.assertTrue(isinstance(place, str) or isinstance(place, unicode))
+            self.assertEqual(type(nested_place_metadata), dict)
+            self.assertIn('categories', nested_place_metadata)
+            self.assertIn('distance', nested_place_metadata)
+            category_list = nested_place_metadata['categories']
             self.assertEqual(type(category_list), list)
             category = category_list[0]
             self.assertTrue(isinstance(category, str) or isinstance(category, unicode))


### PR DESCRIPTION
Summary: Return distance information to places, so we can potentially order or show place experiences by confidence.

Tests:
<img width="759" alt="image" src="https://user-images.githubusercontent.com/5459644/55418680-c39ebb00-5538-11e9-9a81-2fc11cbfa278.png">

5 passing in
`python -m unittest test_yelp`

3 passing in
`python -m unittest test_main`
